### PR TITLE
Fix dedicated server crashes + passenger-seat entering conflict

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <modDesc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" descVersion="107" xsi:noNamespaceSchemaLocation="https://validation.gdn.giants-software.com/xml/fs25/modDesc.xsd">
-  <author>TempletonPeck</author>
-  <version>0.2.7.0</version>
+  <author>TempletonPeck &amp; Nozem_Oil_1982</author>
+  <version>0.2.7.1</version>
 
   <title>
     <en>Cab Cinematic</en>
@@ -20,6 +20,8 @@
   </description>
 
   <iconFilename>icon.dds</iconFilename>
+
+  <multiplayer supported="true" />
 
   <l10n filenamePrefix="translations/translation" />
 

--- a/scripts/CabCinematicVehicleAnalyzer.lua
+++ b/scripts/CabCinematicVehicleAnalyzer.lua
@@ -30,13 +30,45 @@ function CabCinematicVehicleAnalyzer:getVehicleIndoorCameraPosition()
 end
 
 --- Gets the vehicle exit position relative to vehicle root
---- @return table Position {x, y, z}
-function CabCinematicVehicleAnalyzer:getVehicleExitPosition()
-  local exitNode = self.vehicle:getExitNode()
-  if exitNode ~= nil and exitNode ~= 0 then
-    return { localToLocal(getParent(exitNode), self.vehicle.rootNode, getTranslation(exitNode)) }
+--- @param characterFootPosition table Character foot position {x, y, z}, used as a fallback reference
+--- @return table position, boolean isFallback
+function CabCinematicVehicleAnalyzer:getVehicleExitPosition(characterFootPosition)
+  -- We intentionally read the base Enterable exit node directly instead of calling
+  -- vehicle:getExitNode(), which can dispatch into other specializations (e.g. a passenger
+  -- seat) that provide a *contextual* exit node and assume a player is already seated. That
+  -- assumption doesn't hold here since this analysis can run before anyone has entered, and on
+  -- some vehicles it errors as a result. We just need a stable reference position for the
+  -- vehicle's own (driver) exit point, which is exactly what this field holds by default.
+  local exitNode = self.vehicle.spec_enterable ~= nil and self.vehicle.spec_enterable.exitNode or nil
+
+  if exitNode == nil or exitNode == 0 then
+    -- Fall back to the normal call chain in case some vehicle doesn't expose the field the
+    -- usual way, still guarded in case that chain is the one causing trouble.
+    local ok, result = pcall(function()
+      return self.vehicle:getExitNode()
+    end)
+    if ok then
+      exitNode = result
+    end
   end
-  return { 0, 0, 0 }
+
+  if exitNode ~= nil and exitNode ~= 0 then
+    return { localToLocal(getParent(exitNode), self.vehicle.rootNode, getTranslation(exitNode)) }, false
+  end
+
+  -- Last resort: no valid exit node could be determined at all (analysis-time call into
+  -- another specialization failed). Falling back to the vehicle root (0,0,0) would place the
+  -- reference point at the chassis center, which can be far from the cab and produce a broken
+  -- animation path. The character's feet position (from the seat's own IK targets, unrelated
+  -- to getExitNode) is a much closer real-world approximation of where a driver would stand.
+  -- This is still centered (close to X=0) though, so callers should correct its X using a
+  -- properly off-center reference (e.g. accessWheel) once one is available; isFallback=true
+  -- signals that this correction is needed.
+  if characterFootPosition ~= nil then
+    return { characterFootPosition[1], characterFootPosition[2], characterFootPosition[3] }, true
+  end
+
+  return { 0, 0, 0 }, true
 end
 
 --- Gets analysis of a pneumatic wheel
@@ -1078,16 +1110,17 @@ function CabCinematicVehicleAnalyzer:analyze()
   local debugPositions = {}
   local debugHits = {}
 
-  -- Base positions
   local positions = {
     root = { localToLocal(getParent(self.vehicle.rootNode), self.vehicle.rootNode, getTranslation(self.vehicle.rootNode)) },
     camera = self:getVehicleIndoorCameraPosition(),
-    exit = self:getVehicleExitPosition()
   }
 
   positions.seat = { positions.camera[1], positions.camera[2], positions.camera[3] }
   positions.characterFoot = self:getCabCharacterFootPosition(positions)
   positions.steeringWheel = self:getVehicleSteeringWheelPosition(positions)
+
+  local exit, exitIsFallback = self:getVehicleExitPosition(positions.characterFoot)
+  positions.exit = exit
 
   -- Wheel analysis
   local wheelsAnalysis = self:getWheelsAnalysis(positions)
@@ -1096,6 +1129,26 @@ function CabCinematicVehicleAnalyzer:analyze()
 
   -- Access wheel position
   positions.accessWheel = self:getCabAccessWheelPosition(positions)
+
+  -- getVehicleExitPosition's fallback above (used when getExitNode() is unreliable, see its
+  -- own comments) is centered on the seat/pedals (X close to 0), which breaks the
+  -- front/side/rear/left/right entry classification further down (it needs an off-center X
+  -- to tell which side the vehicle is entered from). For tractors, real-world convention (and
+  -- this mod's own door logic) overwhelmingly uses the left-hand door, so default to that side
+  -- directly instead of trying to derive it from other analysis (like accessWheel), which can
+  -- disagree with the door analysis and produce an inconsistent, zig-zagging path.
+  if exitIsFallback then
+    if CabCinematicUtil.isVehicleTractor(self.vehicle) then
+      -- Positive X consistently corresponds to the vehicle's left side in this analyzer's own
+      -- convention (see e.g. getCabAnalysis's left/right positions), so +1.1 approximates a
+      -- typical cab half-width offset toward the left-hand door. The Y value must be near
+      -- ground/step level, not seat height (characterFoot's Y is ~1.5, seat/pedal height,
+      -- which otherwise leaves the player standing near the cab roof after exiting).
+      positions.exit = { 1.8, positions.root[2] + 0.4, positions.exit[3] + 0.15 }
+    elseif positions.accessWheel ~= nil then
+      positions.exit = { positions.accessWheel[1], positions.root[2] + 0.4, positions.exit[3] + 0.15 }
+    end
+  end
 
   -- Cab analysis
   local cabAnalysis = self:getCabAnalysis(positions)

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -20,6 +20,10 @@ function CabCinematic:loadMap()
 end
 
 function CabCinematic:startMission()
+  if g_dedicatedServerInfo ~= nil then
+    return
+  end
+
   g_localPlayer.targeter:addTargetType(CabCinematic, CollisionFlag.VEHICLE, 0.1, CabCinematicUtil.VEHICLE_TARGET_DISTANCE)
   g_localPlayer.targeter:addFilterToTargetType(CabCinematic, function(hitNode)
     if hitNode ~= nil and hitNode ~= 0 and CollisionFlag.getHasGroupFlagSet(hitNode, CollisionFlag.VEHICLE) then
@@ -42,6 +46,10 @@ function CabCinematic:startMission()
 end
 
 function CabCinematic:draw()
+  if g_dedicatedServerInfo ~= nil then
+    return
+  end
+
   if self.debugLevel > 0 then
     local vehicle = g_localPlayer.targetedVehicle
     if vehicle ~= nil and vehicle.drawCabCinematicDebug ~= nil then
@@ -69,6 +77,11 @@ function CabCinematic:onDebugConsoleCommand(level)
 end
 
 function CabCinematic:onInvalidateAnalysisConsoleCommand()
+  if g_dedicatedServerInfo ~= nil then
+    Log:info("Command not available on a dedicated server")
+    return
+  end
+
   local vehicle = g_localPlayer.targetedVehicle or g_localPlayer:getCurrentVehicle()
   if vehicle ~= nil and vehicle.spec_cabCinematic ~= nil then
     self:onReloadConfigurationsConsoleCommand()
@@ -84,24 +97,30 @@ function CabCinematic:onReloadConfigurationsConsoleCommand()
   Log:info("Reloaded vehicle configurations")
 end
 
-PlayerCamera.makeCurrent = Utils.overwrittenFunction(PlayerCamera.makeCurrent, function(playerCamera, superFunc, ...)
-  local vehicle = playerCamera.player:getCurrentVehicle()
-  if vehicle ~= nil and vehicle.spec_cabCinematic ~= nil and vehicle:getIsCabCinematicAnimationOngoing() then
-    return
-  end
+-- The hooks below touch client-only classes (player camera / in-game GUI).
+-- A dedicated server has no local player and does not use these classes the
+-- same way, so skip registering them there to avoid a nil-value error on
+-- server start.
+if g_dedicatedServerInfo == nil then
+  PlayerCamera.makeCurrent = Utils.overwrittenFunction(PlayerCamera.makeCurrent, function(playerCamera, superFunc, ...)
+    local vehicle = playerCamera.player:getCurrentVehicle()
+    if vehicle ~= nil and vehicle.spec_cabCinematic ~= nil and vehicle:getIsCabCinematicAnimationOngoing() then
+      return
+    end
 
-  return superFunc(playerCamera, ...)
-end)
+    return superFunc(playerCamera, ...)
+  end)
 
-InGameMenuSettingsFrame.onFrameOpen = Utils.appendedFunction(InGameMenuSettingsFrame.onFrameOpen, function(settingsFrame)
-  if CabCinematic.settings ~= nil then
-    CabCinematic.settings:initGui(settingsFrame)
-    CabCinematic.settings:updateGui(settingsFrame)
-  end
-end)
+  InGameMenuSettingsFrame.onFrameOpen = Utils.appendedFunction(InGameMenuSettingsFrame.onFrameOpen, function(settingsFrame)
+    if CabCinematic.settings ~= nil then
+      CabCinematic.settings:initGui(settingsFrame)
+      CabCinematic.settings:updateGui(settingsFrame)
+    end
+  end)
 
-InGameMenuSettingsFrame.onFrameClose = Utils.appendedFunction(InGameMenuSettingsFrame.onFrameClose, function(_)
-  if CabCinematic.settings ~= nil then
-    CabCinematic.settings:save()
-  end
-end)
+  InGameMenuSettingsFrame.onFrameClose = Utils.appendedFunction(InGameMenuSettingsFrame.onFrameClose, function(_)
+    if CabCinematic.settings ~= nil then
+      CabCinematic.settings:save()
+    end
+  end)
+end

--- a/scripts/specs/CabCinematicSpec.lua
+++ b/scripts/specs/CabCinematicSpec.lua
@@ -23,6 +23,18 @@ function CabCinematicSpec.registerOverwrittenFunctions(vehicleType)
   SpecializationUtil.registerOverwrittenFunction(vehicleType, "doLeaveVehicle", CabCinematicSpec.doLeaveVehicle)
   SpecializationUtil.registerOverwrittenFunction(vehicleType, "getExitNode", CabCinematicSpec.getExitNode)
 
+  -- The functions below are registered on shared/global classes (not per vehicle instance).
+  -- registerOverwrittenFunctions runs once for every vehicle TYPE that includes this
+  -- specialization, so without this guard the same global function would get wrapped
+  -- again and again (once per supported vehicle type), stacking dozens of redundant
+  -- layers on top of each other. That's wasteful and can cause unexpected side effects
+  -- (e.g. with other specializations hooking the same functions, like passenger seats),
+  -- especially noticeable in multiplayer. Only patch these once, ever.
+  if CabCinematicSpec.globalFunctionsPatched then
+    return
+  end
+  CabCinematicSpec.globalFunctionsPatched = true
+
   -- Entering/leaving overwriting
   PlayerInputComponent.onInputEnter = Utils.overwrittenFunction(PlayerInputComponent.onInputEnter, CabCinematicSpec.onPlayerActionInputEnter)
   Enterable.actionEventLeave = Utils.overwrittenFunction(Enterable.actionEventLeave, CabCinematicSpec.onPlayerActionInputLeave)
@@ -52,6 +64,7 @@ function CabCinematicSpec:onPreLoad()
   spec.storeCategory                = nil
   spec.indoorCamera                 = nil
   spec.analysis                     = nil
+  spec.analysisFailed                = false
   spec.animation                    = nil
   spec.playerEnterPosition          = nil
   spec.allowStartAnimation          = false
@@ -65,8 +78,17 @@ end
 
 --- Initializes the spec when the vehicle is loaded
 function CabCinematicSpec:onLoad()
-  local spec           = self.spec_cabCinematic
-  spec.camera          = CabCinematicCamera.new(self)
+  local spec = self.spec_cabCinematic
+
+  -- A dedicated server never renders anything and has no use for an actual engine camera.
+  -- Creating one anyway (as before) registers it globally with g_cameraManager on every
+  -- single supported vehicle, purely wasted overhead on a server, and risks interfering
+  -- with other systems that track vehicles by camera index (e.g. passenger seats). Only
+  -- create the real camera on clients / listen-server hosts that actually render.
+  if g_dedicatedServerInfo == nil then
+    spec.camera = CabCinematicCamera.new(self)
+  end
+
   spec.vehicleAnalyzer = CabCinematicVehicleAnalyzer.new(self)
   spec.inputComponent  = CabCinematicInputComponent.new(self)
   spec.accessNode      = createTransformGroup("cc_accessNode")
@@ -265,47 +287,78 @@ end
 --- @param playerInputComponent table The PlayerInputComponent instance
 --- @param superFunc function The original onInputEnter function
 --- @param ... any additional arguments
-function CabCinematicSpec.onPlayerActionInputEnter(playerInputComponent, superFunc, ...)
-  local player = playerInputComponent.player
-  local vehicle = playerInputComponent.player.targetedVehicle
-  if vehicle ~= nil and vehicle.spec_cabCinematic ~= nil then
-    local spec = vehicle.spec_cabCinematic
-    spec.playerEnterPosition = nil
-    spec.allowStartAnimation = false
+function CabCinematicSpec.decideOnPlayerActionInputEnter(vehicle, player)
+  local spec = vehicle.spec_cabCinematic
+  spec.playerEnterPosition = nil
+  spec.allowStartAnimation = false
 
-    if not vehicle:getIsCabCinematicSupported() then
-      return superFunc(playerInputComponent, ...)
-    end
+  if not vehicle:getIsCabCinematicSupported() then
+    return "call_super"
+  end
 
-    if vehicle:getIsCabCinematicAnimationOngoing() then
-      return
-    end
+  if vehicle:getIsCabCinematicAnimationOngoing() then
+    return "swallow"
+  end
 
-    if not CabCinematicUtil.isOnFootPlayerInFirstPerson(player) then
-      return superFunc(playerInputComponent, ...)
-    end
+  if not CabCinematicUtil.isOnFootPlayerInFirstPerson(player) then
+    return "call_super"
+  end
 
-    if not CabCinematicUtil.isPlayerInVehicleAccessRange(player, vehicle, CabCinematicUtil.VEHICLE_INTERACT_DISTANCE) then
-      return
-    end
+  -- If the analysis is unavailable (never computed yet, or permanently failed, see
+  -- getCabCinematicAnalysis), treat this vehicle as unsupported and let the normal game
+  -- entering take over, instead of relying on isPlayerInVehicleAccessRange below: that
+  -- function also returns false when there's no analysis, which would otherwise be
+  -- mistaken for "player is just too far away" and swallow the input forever.
+  if vehicle:getCabCinematicAnalysis() == nil then
+    return "call_super"
+  end
 
-    local prerequisiteAnimation = vehicle:getCabCinematicPrerequisiteAnimation()
-    if prerequisiteAnimation ~= nil then
-      if not prerequisiteAnimation.getIsFinished() then
-        if not prerequisiteAnimation.getIsPlaying() then
-          prerequisiteAnimation.play()
-        end
+  if not CabCinematicUtil.isPlayerInVehicleAccessRange(player, vehicle, CabCinematicUtil.VEHICLE_INTERACT_DISTANCE) then
+    return "swallow"
+  end
 
-        return
+  local prerequisiteAnimation = vehicle:getCabCinematicPrerequisiteAnimation()
+  if prerequisiteAnimation ~= nil then
+    if not prerequisiteAnimation.getIsFinished() then
+      if not prerequisiteAnimation.getIsPlaying() then
+        prerequisiteAnimation.play()
       end
 
-      vehicle:invalidateCabCinematicAnalysisCache()
+      return "swallow"
     end
 
-    -- We capture player positions to adapt (shortcut or expand) the animation based on where the player is entering from.
-    spec.playerEnterPosition = { localToLocal(player.camera.cameraRootNode, vehicle.rootNode, getTranslation(player.camera.cameraRootNode)) }
-    spec.lastInteractionTime = g_time
-    spec.allowStartAnimation = true
+    vehicle:invalidateCabCinematicAnalysisCache()
+  end
+
+  -- We capture player positions to adapt (shortcut or expand) the animation based on where the player is entering from.
+  spec.playerEnterPosition = { localToLocal(player.camera.cameraRootNode, vehicle.rootNode, getTranslation(player.camera.cameraRootNode)) }
+  spec.lastInteractionTime = g_time
+  spec.allowStartAnimation = true
+
+  return "call_super"
+end
+
+function CabCinematicSpec.onPlayerActionInputEnter(playerInputComponent, superFunc, ...)
+  local player = playerInputComponent.player
+  if player == nil then
+    return superFunc(playerInputComponent, ...)
+  end
+
+  local vehicle = player.targetedVehicle
+  if vehicle ~= nil and vehicle.spec_cabCinematic ~= nil then
+    -- Wrapped in pcall: an error anywhere in this decision chain (e.g. triggered by another
+    -- specialization's collision/trigger code while analyzing the vehicle, see
+    -- getCabCinematicAnalysis) must never block the player from entering the vehicle at all.
+    local ok, result = pcall(CabCinematicSpec.decideOnPlayerActionInputEnter, vehicle, player)
+
+    if not ok then
+      Log:warning("Cab cinematic enter check failed for '%s', falling back to normal entering. (%s)", tostring(vehicle:getFullName()), tostring(result))
+      return superFunc(playerInputComponent, ...)
+    end
+
+    if result == "swallow" then
+      return
+    end
   end
 
   return superFunc(playerInputComponent, ...)
@@ -515,8 +568,27 @@ function CabCinematicSpec:getCabCinematicAnalysis()
     return self.spec_cabCinematic.analysis
   end
 
+  if self.spec_cabCinematic.analysisFailed then
+    return nil
+  end
+
   if self:getIsCabCinematicSupported() then
-    self.spec_cabCinematic.analysis = self.spec_cabCinematic.vehicleAnalyzer:analyze()
+    -- The analysis raycasts through the cab to detect its boundaries. On some vehicles this
+    -- raycast can intersect other specializations' collision/trigger geometry (e.g. a
+    -- passenger seat) and cause an error inside their code, unrelated to this mod itself.
+    -- Guard against that so a single problematic vehicle can never break entering into it,
+    -- or spam errors on every attempt; that vehicle simply won't get the cinematic animation.
+    local ok, result = pcall(function()
+      return self.spec_cabCinematic.vehicleAnalyzer:analyze()
+    end)
+
+    if not ok then
+      Log:warning("Could not analyze '%s' for cab cinematic, disabling it for this vehicle. (%s)", tostring(self:getFullName()), tostring(result))
+      self.spec_cabCinematic.analysisFailed = true
+      return nil
+    end
+
+    self.spec_cabCinematic.analysis = result
     return self.spec_cabCinematic.analysis
   end
 


### PR DESCRIPTION
## Issues this fixes

1. **Dedicated server crash on startup** — `g_localPlayer` doesn't exist on a
   dedicated server, and `PlayerCamera`/`InGameMenuSettingsFrame` are referenced
   unconditionally when the mod loads. This crashed the session as soon as the
   mission started on a dedicated server.

2. **"Uploaded mod has no multiplayer support"** — missing
   `<multiplayer supported="true" />` in modDesc.xml, causing the dedicated
   server web interface to reject the mod outright.

3. **Stacked global function overwrites** — `registerOverwrittenFunctions`
   patches several *global* functions (`PlayerInputComponent.onInputEnter`,
   etc.) but is called once per vehicle type. Without a guard, the same global
   function got wrapped dozens of times (once per supported vehicle type).

4. **Crash on vehicles with a passenger seat (`EnterablePassenger`)** —
   `getVehicleExitPosition()` called `vehicle:getExitNode()` during vehicle
   analysis (i.e. before anyone has actually entered). On vehicles with a
   passenger seat, this dispatches into `EnterablePassenger`'s own exit-node
   logic, which assumes a player is already seated there — and errors
   (`EnterablePassenger.lua:457: attempt to index nil with 'userId'`) when
   that isn't the case. This completely blocked entering some tractors/
   harvesters in multiplayer.

## Fix

- Added dedicated-server checks (`g_dedicatedServerInfo`) around all
  client-only code in `main.lua`; the cinematic camera is no longer created
  on the server itself.
- Added `<multiplayer supported="true" />` to modDesc.xml.
- Made the global function-overwrite registration idempotent.
- `getCabCinematicAnalysis()` now catches errors during analysis (`pcall`);
  on failure, cinematic is simply disabled for that one vehicle (normal
  entering always still works), instead of crashing the whole analysis or
  input handling.
- `getVehicleExitPosition()` now reads the exit node directly from
  `spec_enterable.exitNode` instead of through the (fragile) function chain,
  with a fallback that defaults to the left-hand door convention for
  tractors when no reliable exit node can be found.

Tested extensively (locally and on a dedicated server) with several
tractors/mods, specifically including vehicles with a passenger seat (Fendt
900TMS, Fendt 800/900 Vario Gen5).